### PR TITLE
Added More Domains Than .com

### DIFF
--- a/JarvisAI/JarvisAI/JarvisAI/features/website_open/website_open.py
+++ b/JarvisAI/JarvisAI/JarvisAI/features/website_open/website_open.py
@@ -1,12 +1,55 @@
 import webbrowser
+import requests
 import re
+
+DOMAINS = [
+    ".com",
+    ".io",
+    ".xyz",
+    ".co",
+    ".uk",
+    ".gov.uk",
+    ".gov",
+    ".scot",
+    "co.uk",
+    ".shop",
+    ".org",
+    ".org.uk",
+    ".net",
+    ".ai",
+    ".ca",
+    ".dev",
+    ".me",
+    ".art",
+    ".health",
+    ".live",
+    ".info",
+    ".studio",
+    ".biz",
+    ".gay",
+    ".cc",
+    ".so",
+    ".to",
+    ".ac",
+    ".cx",
+    ".sh"
+]
 
 
 def website_opener(domain):
     extension = re.search(r"[.]", domain)
     if not extension:
-        if not domain.endswith(".com"):
-            domain = domain + ".com"
+        for i in DOMAINS:
+            try:
+                result = requests.get(f'http://{domain}{i}', timeout=10)
+                result = str(result).split(" ")
+                result = result[1].replace(">", "")
+
+                if result == "[200]":
+                    domain = domain + i
+                    print(domain)
+            except:
+                continue
     try:
         url = 'https://www.' + domain
         webbrowser.open(url)


### PR DESCRIPTION
I use jarvis for small projects and I thought to commit to the project so I have added the below

The domain that comes into the function might not always be a .com domain for example I always 
.xyz or .dev for my domains so to make it easy for the end user I added a list which holds all the domains
I can remember I will add more.

DOMAINS = [
    ".com",
    ".io",
    ".xyz",
    ".co",
    ".uk",
    ".gov.uk",
    ".gov",
    ".scot",
    "co.uk",
    ".shop",
    ".org",
    ".org.uk",
    ".net",
    ".ai",
    ".ca",
    ".dev",
    ".me",
    ".art",
    ".health",
    ".live",
    ".info",
    ".studio",
    ".biz",
    ".gay",
    ".cc",
    ".so",
    ".to",
    ".ac",
    ".cx",
    ".sh"
]

And if you pass a website without an extension it will check the domains using
requests and if its a 403 or 404 it will continue if its a 200 it will add the extension
to your domain name.

        for i in DOMAINS:
            try:
                result = requests.get(f'http://{domain}{i}', timeout=10)
                result = str(result).split(" ")
                result = result[1].replace(">", "")

                if result == "[200]":
                    domain = domain + i
                    print(domain)
            except:
                continue

There are my changes  =)